### PR TITLE
Terminal code fix

### DIFF
--- a/static/css/sources/components/terminal.less
+++ b/static/css/sources/components/terminal.less
@@ -7,19 +7,17 @@
 	}
 
 	&_code {
-		clear: left;
+		display: table;
 		min-height: 42px;
-		padding: 15px 0;
-		color: #F1F1F1;
+		padding: 10px 0;
+		color: #f1f1f1;
 		font-family: monospace;
 		font-size: 12px;
-		line-height: 19px;
+		line-height: 18px;
 		white-space: pre-wrap;
 		word-wrap: break-word;
 		background-color: #2a2a2a;
 		counter-reset: line-numbering;
-		margin-top: 0;
-		overflow-y: scroll;
 	}
 
 	&_footer {
@@ -28,24 +26,24 @@
 }
 
 .code-line {
-	position: relative;
-	padding: 0 15px 0 55px;
-	margin: 0;
-	min-height: 16px;
+	display: table-row;
 
 	&_counter {
-		display: inline-block;
+		display: table-cell;
+		vertical-align: top;
+		width: 1px;
 		text-align: right;
-		min-width: 40px;
-		margin-left: -33px;
 		cursor: pointer;
 		text-decoration: none;
 		color: darken(@gray-lighter, 15%);
+		padding: 0 10px;
+		border-right: 1px solid rgba(255, 255, 255, 0.1);
+
 		&:before {
 			content: counter(line-numbering);
 			counter-increment: line-numbering;
-			padding-right: 1em;
 		}
+
 		&:hover {
 			text-decoration: none;
 			color: @gray-lighter;
@@ -53,7 +51,9 @@
 	}
 
 	&_body {
-		display: inline-block;
+		display: table-cell;
+		vertical-align: top;
+    		padding: 0 10px;
 	}
 
 	&:hover {


### PR DESCRIPTION
I think it's better to use table-like layout to show code with line numbers because numbers width is dynamic and should be syncronized in each rows.