### PR TITLE
git: use author name and date instead of commiter

### DIFF
--- a/lib/scm/git.js
+++ b/lib/scm/git.js
@@ -19,7 +19,7 @@ Scm.prototype._fieldsSeparator = '\u2063' + '\u2063';
 Scm.prototype._linesSeparator = '\u2028' + '\u2028';
 
 Scm.prototype._revTemplate = [
-	'%h', '%cn', '%cd', '%s', '%d'
+	'%h', '%an', '%ad', '%s', '%d'
 ].join(Scm.prototype._fieldsSeparator);
 
 Scm.prototype._parseRev = function(str) {


### PR DESCRIPTION
because after rebase commiter may be different person