### PR TITLE
fix cryptic port in use error

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ app.httpServer = httpServer.create();
 
 app.httpServer.on('error', function(err, req, res) {
 	httpServerLogger.error(
-		'Error processing request ' + req.method + ' ' + req.url + ':',
+                'Error processing request ' + (req&&req.method) + ' ' + (req&&req.url) + ':',
 		err.stack || err
 	);
 	if (!res.headersSent) {


### PR DESCRIPTION
First run got me a crash, which was reported like this.

```
[Wed, 29 Jun 2016 20:22:06 GMT] [app] Start http server on 127.0.0.1:3000
/home/kriss/t/dd/nci-quick-setup/node_modules/nci/app.js:36
		'Error processing request ' + req.method + ' ' + req.url + ':',
		                                 ^

TypeError: Cannot read property 'method' of undefined
    at Server.<anonymous> (/home/kriss/t/dd/nci-quick-setup/node_modules/nci/app.js:36:36)
    at emitOne (events.js:77:13)
    at Server.emit (events.js:169:7)
    at emitErrorNT (net.js:1250:8)
    at doNTCallback2 (node.js:429:9)
    at process._tickCallback (node.js:343:17)

```

so here is a dumb patch to stop that happening to someone else, now the error looks like this and was of course easily fixed.

```
[Wed, 29 Jun 2016 20:24:06 GMT] [http server] Error processing request undefined undefined: Error: listen EADDRINUSE 127.0.0.1:3000
    at Object.exports._errnoException (util.js:837:11)
    at exports._exceptionWithHostPort (util.js:860:20)
    at Server._listen2 (net.js:1231:14)
    at listen (net.js:1267:10)
    at net.js:1370:9
    at doNTCallback3 (node.js:440:9)
    at process._tickCallback (node.js:346:17)

```