### PR TITLE
Fix git pull operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.idea
 test/workspace
 test/distributor/workspace
 test/repos/mercurial/

--- a/lib/scm/git.js
+++ b/lib/scm/git.js
@@ -82,7 +82,7 @@ Scm.prototype.pull = function(rev, callback) {
 		},
 		function(err, currentRev) {
 			this.pass(currentRev);
-			self._run({cmd: 'git', args: ['pull']}, this.slot());
+			self._run({cmd: 'git', args: ['pull', '--rebase']}, this.slot());
 		},
 		function(err, currentRev) {
 			self.update(currentRev.id, this.slot());


### PR DESCRIPTION
`git pull` in NCI create `Merge branch 'develop' of ...` commits if branch been rebased.
These unnecessary merge commits can interfere with build scripts