### PR TITLE
Allow development with `npm link`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "conform": "0.2.12",
     "junk": "1.0.3",
     "nlevel": "1.0.3",
+    "require-relative": "0.8.7",
     "through": "2.3.6",
     "tree-kill": "1.1.0",
     "twostep": "0.4.2",


### PR DESCRIPTION
This PR fixes problem when `npm link` is used to link nci package to the project working directory (for example [nci-quick-setup](https://github.com/node-ci/nci-quick-setup)). Problem is described below. Also I make some refactoring in app/config.js and app/index.js

I have such folders structure:
```
nci
|--- nci                  (npm link)
|--- nci-classic-ui       (npm link)
|--- nci-quick-setup      (npm link nci, npm link nci-classic-ui)
```
When I run `nci` inside nci-quick-setup folder I get:
```
~/projects/nci/nci/app.js:8
	if (err) throw err;
	         ^

Error: Cannot find module 'leveldown'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Group.self.projects.ProjectsCollection.db (/home/webster/projects/github/nci/nci/app/index.js:72:20)
    at Group.<anonymous> (/home/webster/projects/github/nci/nci/node_modules/twostep/lib/twoStep.js:171:15)
    at next (/home/webster/projects/github/nci/nci/node_modules/twostep/lib/twoStep.js:159:9)
    at Group.done (/home/webster/projects/github/nci/nci/node_modules/twostep/lib/twoStep.js:30:16)
    at Group._fillSlot (/home/webster/projects/github/nci/nci/node_modules/twostep/lib/twoStep.js:52:8)
    at /home/webster/projects/github/nci/nci/node_modules/twostep/lib/twoStep.js:77:9
```

This happens because `nci` tries to require `leveldown`, but `leveldown` is a dependency of `nci-quick-setup` (custom db backand).
Solving the problem is to do require call relative to cwd. I add [require-relative](https://github.com/kamicane/require-relative) and add method app.require that is used to require all external deps (db backend, plugins, proload.json).