### PR TITLE
Added 'buildScmUpdated' event

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -27,6 +27,7 @@ BuildsCollection.prototype.setDistributor = function(distributor) {
 	this._proxyDistributorEvent('buildCompleted', 'buildCompleted');
 	this._proxyDistributorEvent('buildCanceled', 'buildCanceled');
 	this._proxyDistributorEvent('buildLogLines', 'buildLogLines');
+	this._proxyDistributorEvent('buildScmUpdated', 'buildScmUpdated');
 };
 
 BuildsCollection.prototype._proxyDistributorEvent = function(source, dest) {

--- a/lib/distributor.js
+++ b/lib/distributor.js
@@ -257,6 +257,7 @@ Distributor.prototype._runNext = function(callback) {
 
 				executor.once('scmData', function(scmData) {
 					self._updateBuild(build, {scm: scmData});
+					self.emit('buildScmUpdated', build);
 					// run the same project again if we don't reach the latest rev
 					if (!scmData.isLatest) {
 						self.run({


### PR DESCRIPTION
While developing plugins for node-ci, I needed the ability to edit build files after they were checked out, but before the steps were run. To address this, I added a 'buildScmUpdated' event that is called right after a scm update is performed.