### PR TITLE
Script files can now be used as step commands

### DIFF
--- a/lib/command/shell.js
+++ b/lib/command/shell.js
@@ -21,6 +21,11 @@ function Command(params) {
 	this.shellExtraArgs = params.shellExtraArgs || [];
 }
 
+
+function isScript(str){
+	return (process.platform === 'win32' && str.endsWith('.bat')) || (process.platform !== 'win32' && str.endsWith('.sh'));
+}
+
 exports.Command = Command;
 
 inherits(Command, ParentCommand);
@@ -33,7 +38,7 @@ inherits(Command, ParentCommand);
 Command.prototype.run = function(params, callback) {
 	return ParentCommand.prototype.run.call(this, {
 		cmd: this.shell,
-		args: this.shellExtraArgs.concat(this.shellCmdArg).concat(params.cmd),
+		args: isScript(params.cmd) ? this.shellExtraArgs.concat(params.cmd) : this.shellExtraArgs.concat(this.shellCmdArg).concat(params.cmd),
 		options: params.options,
 		envVars: params.envVars
 	}, callback);


### PR DESCRIPTION
By default, project steps should be shell commands. This pull request adds support for calling script files (bash scripts on *nix systems and batch files on windows systems) directly. This allows users to better organize and reuse long commands while maintaining project config file readability.