### PR TITLE
Added 'started' strategy for build notifications

### DIFF
--- a/lib/distributor.js
+++ b/lib/distributor.js
@@ -257,6 +257,7 @@ Distributor.prototype._runNext = function(callback) {
 
 				executor.once('scmData', function(scmData) {
 					self._updateBuild(build, {scm: scmData});
+					self.notifier.send(build);
 					// run the same project again if we don't reach the latest rev
 					if (!scmData.isLatest) {
 						self.run({

--- a/lib/notifier/index.js
+++ b/lib/notifier/index.js
@@ -89,10 +89,6 @@ Notifier.prototype.send = function(build, callback) {
 
 	Steppy(
 		function() {
-			if (!build.completed) {
-				throw new Error('Build should be completed before notify');
-			}
-
 			var notify = build.project.notify;
 
 			// TODO: move to project validation during load
@@ -111,7 +107,9 @@ Notifier.prototype.send = function(build, callback) {
 		},
 		function(err, notify, prevBuild) {
 			var strategy = _(notify.on).find(function(strategy) {
-				if (strategy === 'done') {
+				if (strategy === 'started') {
+					return build.status === 'in-progress';
+				} else if (strategy === 'done') {
 					return build.status === 'done';
 				} else if (strategy === 'error') {
 					return build.status === 'error';


### PR DESCRIPTION
This pull request adds a 'started' strategy for build notifications. Most teams are using things like Slack for build notifications now, and it's helpful to know when builds are started, not just when they complete. 

Note: This event is called after an scm update so the "changes" object is available in the notifier.